### PR TITLE
Add a .formatter.exs to export the DSL

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,15 @@
+locals_without_parens = [
+  aliases: 1,
+  argument: 2,
+  description: 1,
+  long_description: 1,
+  name: 1,
+  option: 2,
+  default_command: 1
+]
+
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
+]


### PR DESCRIPTION
To prevent `mix format` from putting parentheses on `name/1`, `option/1` and so on, we currently need to add these macros by hand in our `.formatter.exs`. This files also allows to export and import the list of macros which should not have parentheses. With this PR, one can do:

```elixir
[
  import_deps: [:ex_cli]
]
```

in its `.formatter.exs` to automatically avoid `mix format` putting parenthese on the DSL macros.