### PR TITLE
Add .formatter.exs to the Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule ExCLI.Mixfile do
   defp package do
     [
       maintainers: ["Daniel Perez"],
-      files: ["lib", "mix.exs", "README.md"],
+      files: ["lib", "mix.exs", ".formatter.exs", "README.md"],
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/tuvistavie/ex_cli",


### PR DESCRIPTION
`import_deps: [:ex_cli]` does not currently work since the `.formatter.exs` is not included in the Hex package. I’ve added it to the list to fix this issue.